### PR TITLE
Create polyfill to support PHP 8.0, 8.1 and PHPUnit 9.0

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -1,0 +1,49 @@
+name: Continuous Integration
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  phpunit:
+    name: PHPUnit
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        operating-system:
+          - ubuntu-latest
+        php-version:
+          - '5.6'
+          - '7.0'
+          - '7.1'
+          - '7.2'
+          - '7.3'
+          - '7.4'
+          - '8.0'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+
+      - name: Setup PHP ${{ matrix.php-version }}
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php-version }}
+          ini-values: zend.assertions=1
+
+      - name: Get composer cache directory
+        id: composer-cache
+        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+
+      - name: Cache dependencies
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+          restore-keys: ${{ runner.os }}-composer-
+
+      - name: Install dependencies
+        run: composer update --no-interaction --no-progress
+
+      - name: Run test suite
+        run: ./vendor/bin/phpunit

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -21,6 +21,7 @@ jobs:
           - '7.3'
           - '7.4'
           - '8.0'
+          - '8.1'
     steps:
       - name: Checkout
         uses: actions/checkout@v1

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -1,10 +1,8 @@
 filter:
     paths: ["src/*"]
-tools:
-    external_code_coverage: true
-    php_code_coverage: true
-    php_sim: true
-    php_mess_detector: true
-    php_pdepend: true
-    php_analyzer: true
-    php_cpd: true
+build:
+    nodes:
+        analysis:
+            tests:
+                override:
+                    - php-scrutinizer-run

--- a/composer.json
+++ b/composer.json
@@ -32,11 +32,14 @@
     },
     "require-dev": {
         "pds/skeleton": "~1.0",
-        "phpunit/phpunit": "~5.0"
+        "phpunit/phpunit": "~5.0 | ~9.0"
     },
     "autoload-dev": {
         "psr-4": {
             "Aura\\Sql\\": "tests/"
-        }
+        },
+        "files": [
+            "tests/polyfill/each.php"
+        ]
     }
 }

--- a/phpunit.php
+++ b/phpunit.php
@@ -1,4 +1,5 @@
 <?php
+
 error_reporting(E_ALL);
 $autoloader = __DIR__ . '/vendor/autoload.php';
 if (! file_exists($autoloader)) {
@@ -7,3 +8,8 @@ if (! file_exists($autoloader)) {
     exit(1);
 }
 require $autoloader;
+if (! class_exists('PHPUnit_Framework_TestCase')) {
+    require __DIR__ . '/tests/polyfill/TestCace.php';
+}else {
+    require __DIR__ . '/tests/polyfill/PHPUnit_Framework_TestCase.php';
+}

--- a/src/AbstractExtendedPdo.php
+++ b/src/AbstractExtendedPdo.php
@@ -125,6 +125,7 @@ abstract class AbstractExtendedPdo extends PDO implements ExtendedPdoInterface
      * @see http://php.net/manual/en/pdo.begintransaction.php
      *
      */
+    #[\ReturnTypeWillChange]
     public function beginTransaction()
     {
         $this->connect();
@@ -143,6 +144,7 @@ abstract class AbstractExtendedPdo extends PDO implements ExtendedPdoInterface
      * @see http://php.net/manual/en/pdo.commit.php
      *
      */
+    #[\ReturnTypeWillChange]
     public function commit()
     {
         $this->connect();
@@ -177,6 +179,7 @@ abstract class AbstractExtendedPdo extends PDO implements ExtendedPdoInterface
      * @return mixed
      *
      */
+    #[\ReturnTypeWillChange]
     public function errorCode()
     {
         $this->connect();
@@ -190,6 +193,7 @@ abstract class AbstractExtendedPdo extends PDO implements ExtendedPdoInterface
      * @return array
      *
      */
+    #[\ReturnTypeWillChange]
     public function errorInfo()
     {
         $this->connect();
@@ -207,6 +211,7 @@ abstract class AbstractExtendedPdo extends PDO implements ExtendedPdoInterface
      * @see http://php.net/manual/en/pdo.exec.php
      *
      */
+    #[\ReturnTypeWillChange]
     public function exec($statement)
     {
         $this->connect();
@@ -493,6 +498,7 @@ abstract class AbstractExtendedPdo extends PDO implements ExtendedPdoInterface
      * @see http://php.net/manual/en/pdo.intransaction.php
      *
      */
+    #[\ReturnTypeWillChange]
     public function inTransaction()
     {
         $this->connect();
@@ -526,6 +532,7 @@ abstract class AbstractExtendedPdo extends PDO implements ExtendedPdoInterface
      * @see http://php.net/manual/en/pdo.lastinsertid.php
      *
      */
+    #[\ReturnTypeWillChange]
     public function lastInsertId($name = null)
     {
         $this->connect();
@@ -574,6 +581,7 @@ abstract class AbstractExtendedPdo extends PDO implements ExtendedPdoInterface
      * @see http://php.net/manual/en/pdo.prepare.php
      *
      */
+    #[\ReturnTypeWillChange]
     public function prepare($statement, $options = [])
     {
         $this->connect();
@@ -603,6 +611,7 @@ abstract class AbstractExtendedPdo extends PDO implements ExtendedPdoInterface
      * @see http://php.net/manual/en/pdo.prepare.php
      *
      */
+    #[\ReturnTypeWillChange]
     public function prepareWithValues($statement, array $values = [])
     {
         // if there are no values to bind ...
@@ -642,6 +651,7 @@ abstract class AbstractExtendedPdo extends PDO implements ExtendedPdoInterface
      * @see http://php.net/manual/en/pdo.query.php
      *
      */
+    #[\ReturnTypeWillChange]
     public function query($statement, ...$fetch)
     {
         $this->connect();
@@ -667,6 +677,7 @@ abstract class AbstractExtendedPdo extends PDO implements ExtendedPdoInterface
      * @see http://php.net/manual/en/pdo.quote.php
      *
      */
+    #[\ReturnTypeWillChange]
     public function quote($value, $type = self::PARAM_STR)
     {
         $this->connect();
@@ -737,6 +748,7 @@ abstract class AbstractExtendedPdo extends PDO implements ExtendedPdoInterface
      * @see http://php.net/manual/en/pdo.rollback.php
      *
      */
+    #[\ReturnTypeWillChange]
     public function rollBack()
     {
         $this->connect();
@@ -987,6 +999,7 @@ abstract class AbstractExtendedPdo extends PDO implements ExtendedPdoInterface
      * @param int $attribute
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function getAttribute($attribute)
     {
         $this->connect();
@@ -1001,6 +1014,7 @@ abstract class AbstractExtendedPdo extends PDO implements ExtendedPdoInterface
      * @param mixed $value
      * @return bool
      */
+    #[\ReturnTypeWillChange]
     public function setAttribute($attribute, $value)
     {
         $this->connect();

--- a/tests/ConnectionLocatorTest.php
+++ b/tests/ConnectionLocatorTest.php
@@ -1,7 +1,7 @@
 <?php
 namespace Aura\Sql;
 
-class ConnectionLocatorTest extends \PHPUnit_Framework_TestCase
+class ConnectionLocatorTest extends \TestCase
 {
     /**
      * @var ConnectionLocator
@@ -16,7 +16,7 @@ class ConnectionLocatorTest extends \PHPUnit_Framework_TestCase
 
     protected $write = [];
 
-    protected function setUp()
+    protected function _setUp()
     {
         $this->conns = [
             'default' => new ExtendedPdo('sqlite::memory:'),

--- a/tests/ExtendedPdoTest.php
+++ b/tests/ExtendedPdoTest.php
@@ -295,7 +295,7 @@ class ExtendedPdoTest extends \TestCase
     {
         $stm = "SELECT id, name FROM pdotest WHERE id = ?";
         $actual = $this->pdo->fetchObject($stm, [1]);
-        $this->assertSame('1', $actual->id);
+        $this->assertSame('1', (string) $actual->id);
         $this->assertSame('Anna', $actual->name);
     }
 
@@ -308,7 +308,7 @@ class ExtendedPdoTest extends \TestCase
             'Aura\Sql\FakeObject',
             ['bar']
         );
-        $this->assertSame('1', $actual->id);
+        $this->assertSame('1', (string) $actual->id);
         $this->assertSame('Anna', $actual->name);
         $this->assertSame('bar', $actual->foo);
     }

--- a/tests/ExtendedPdoTest.php
+++ b/tests/ExtendedPdoTest.php
@@ -4,7 +4,7 @@ namespace Aura\Sql;
 use PDO;
 use stdClass;
 
-class ExtendedPdoTest extends \PHPUnit_Framework_TestCase
+class ExtendedPdoTest extends \TestCase
 {
     /** @var ExtendedPdoInterface */
     protected $pdo;
@@ -22,7 +22,7 @@ class ExtendedPdoTest extends \PHPUnit_Framework_TestCase
         10 => 'Kara',
     ];
 
-    public function setUp()
+    public function _setUp()
     {
         if (! extension_loaded('pdo_sqlite')) {
             $this->markTestSkipped("Need 'pdo_sqlite' to test in memory.");

--- a/tests/Parser/AbstractParserTest.php
+++ b/tests/Parser/AbstractParserTest.php
@@ -1,7 +1,7 @@
 <?php
 namespace Aura\Sql\Parser;
 
-abstract class AbstractParserTest extends \PHPUnit_Framework_TestCase
+abstract class AbstractParserTest extends \TestCase
 {
     protected $parser;
 

--- a/tests/Parser/MysqlParserTest.php
+++ b/tests/Parser/MysqlParserTest.php
@@ -3,7 +3,7 @@ namespace Aura\Sql\Parser;
 
 class MysqlParserTest extends AbstractParserTest
 {
-    protected function setUp()
+    protected function _setUp()
     {
         $this->parser = new MysqlParser();
     }

--- a/tests/Parser/NullParserTest.php
+++ b/tests/Parser/NullParserTest.php
@@ -1,7 +1,7 @@
 <?php
 namespace Aura\Sql\Parser;
 
-class NullParserTest extends \PHPUnit_Framework_TestCase
+class NullParserTest extends \TestCase
 {
     public function test()
     {

--- a/tests/Parser/PgsqlParserTest.php
+++ b/tests/Parser/PgsqlParserTest.php
@@ -3,7 +3,7 @@ namespace Aura\Sql\Parser;
 
 class PgsqlParserTest extends AbstractParserTest
 {
-    protected function setUp()
+    protected function _setUp()
     {
         $this->parser = new PgsqlParser();
     }

--- a/tests/Parser/SqliteParserTest.php
+++ b/tests/Parser/SqliteParserTest.php
@@ -3,7 +3,7 @@ namespace Aura\Sql\Parser;
 
 class SqliteParserTest extends AbstractParserTest
 {
-    protected function setUp()
+    protected function _setUp()
     {
         $this->parser = new SqliteParser();
     }

--- a/tests/Profiler/ProfilerTest.php
+++ b/tests/Profiler/ProfilerTest.php
@@ -3,9 +3,9 @@ namespace Aura\Sql\Profiler;
 
 use Psr\Log\LogLevel;
 
-class ProfilerTest extends \PHPUnit_Framework_TestCase
+class ProfilerTest extends \TestCase
 {
-    protected function setUp()
+    protected function _setUp()
     {
         $this->profiler = new Profiler();
     }

--- a/tests/polyfill/PHPUnit_Framework_TestCase.php
+++ b/tests/polyfill/PHPUnit_Framework_TestCase.php
@@ -1,0 +1,10 @@
+<?php
+class TestCase extends \PHPUnit\Framework\TestCase
+{
+    protected function setUp()
+    {
+        if (method_exists($this, '_setUp')) {
+            $this->_setUp();
+        }
+    }
+}

--- a/tests/polyfill/TestCace.php
+++ b/tests/polyfill/TestCace.php
@@ -1,0 +1,26 @@
+<?php
+
+class TestCase extends \PHPUnit\Framework\TestCase
+{
+    protected function setUp(): void
+    {
+        if (method_exists($this, '_setUp')) {
+            $this->_setUp();
+        }
+    }
+
+    protected function setExpectedException($e)
+    {
+        $this->expectException($e);
+    }
+
+    public static function assertContains($needle, $haystack, string $message = ''): void
+    {
+        if (is_string($haystack)) {
+            self::assertStringContainsString($needle, $haystack, $message);
+
+            return;
+        }
+        parent::assertContains($needle, $haystack, $message);
+    }
+}

--- a/tests/polyfill/each.php
+++ b/tests/polyfill/each.php
@@ -1,0 +1,18 @@
+<?php
+
+// Source: https://gist.github.com/k-gun/30dd2bf8b22329a2dbc11a045aed3859
+if (!function_exists('each')) {
+    function each(array &$array) {
+        $value = current($array);
+        $key = key($array);
+
+        if (is_null($key)) {
+            return false;
+        }
+
+        // Move pointer.
+        next($array);
+
+        return array(1 => $value, 'value' => $value, 0 => $key, 'key' => $key);
+    }
+}


### PR DESCRIPTION
* Use common method signatures `_setUp()` for `setUp()` in phpunit 5 and 9.
* Support `setExpectedException()`, which is not supported by phpunit 9, and `assertContains`, which has changed.
* Create `each` function with polyfill in PHP 8.
* Migrate Travis to GH action